### PR TITLE
Fix collection type labels

### DIFF
--- a/lib/tasks/fix_collection_type_labels.rake
+++ b/lib/tasks/fix_collection_type_labels.rake
@@ -1,0 +1,15 @@
+# Run this if you are seeing Collections with a type of "translation missing..."
+# Check YOUR_SERVER//dashboard/collections?locale=en for a place where this might appear
+namespace :oars do
+  desc "Fix missing collection type labels"
+  task :fix_collection_type_labels => [:environment] do |_t, args|
+    collection_types = Hyrax::CollectionType.all
+    collection_types.each do |c|
+      next unless c.title =~ /^translation missing/
+      oldtitle = c.title
+      c.title = I18n.t(c.title.gsub("translation missing: en.", ''))
+      c.save
+      puts "#{oldtitle} changed to #{c.title}"
+    end
+  end
+end


### PR DESCRIPTION
Run this if you are seeing Collections with a type of "translation missing..."
Check YOUR_SERVER/dashboard/collections?locale=en for a place where this might appear

This is what it should look like if it's running correctly:
![fix_labels](https://user-images.githubusercontent.com/65608/74480760-85c03200-4e7f-11ea-9498-9180b7e2f592.png)
